### PR TITLE
implement timeout (or react to exceptions), issue #10

### DIFF
--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -25,6 +25,7 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_NOT_POSSIBLE_TO_PARSE_REAL_TIME_TASK_XML_DATA = 14;
         public const int RETURN_FAILED_FINDING_DEFINED_UNIT_TEST_TASK_IN_TWINCAT_PROJECT = 15;
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
+        public const int RETURN_TIMEOUT = 17;
 
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";

--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -26,6 +26,7 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_FAILED_FINDING_DEFINED_UNIT_TEST_TASK_IN_TWINCAT_PROJECT = 15;
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
         public const int RETURN_TIMEOUT = 17;
+        public const int RETURN_INVALID_ADSSTATE = 18;
 
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";

--- a/TcUnit-Runner/TcUnit-Runner.csproj
+++ b/TcUnit-Runner/TcUnit-Runner.csproj
@@ -69,11 +69,13 @@
     <Reference Include="envdte90a, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/TcUnit-Runner/TcUnit-Runner.csproj
+++ b/TcUnit-Runner/TcUnit-Runner.csproj
@@ -83,6 +83,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="TwinCAT.Ads, Version=4.4.0.0, Culture=neutral, PublicKeyToken=180016cd49e5e8c3, processorArchitecture=MSIL">
+      <HintPath>..\packages\Beckhoff.TwinCAT.Ads.4.4.10\lib\Net40-full\TwinCAT.Ads.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomationInterface.cs" />

--- a/TcUnit-Runner/XmlUtilities.cs
+++ b/TcUnit-Runner/XmlUtilities.cs
@@ -80,5 +80,17 @@ namespace TcUnit.TcUnit_Runner
             }
             return Convert.ToBoolean(attrPinnedVersion.InnerText);
         }
+
+        /// <summary>
+        /// Returns the Port that is used for a PLC node
+        /// </summary>
+        public static int AmsPort(string plcXml)
+        {
+            XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(plcXml);
+
+            XmlNode nodeAdsPort = xmlDoc.SelectSingleNode("/TreeItem/PlcProjectDef/" + "AdsPort");
+            return Convert.ToInt32(nodeAdsPort.InnerText);
+        }
     }
 }

--- a/TcUnit-Runner/packages.config
+++ b/TcUnit-Runner/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.8" targetFramework="net461" />
+  <package id="log4net" version="2.0.12" targetFramework="net451" />
 </packages>

--- a/TcUnit-Runner/packages.config
+++ b/TcUnit-Runner/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Beckhoff.TwinCAT.Ads" version="4.4.10" targetFramework="net451" />
   <package id="log4net" version="2.0.12" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This pull requests solves the issue that is mentioned in issue #10 .
* An additional option to specify a timeout for the process is implemented. I observed that the automation interfaces does not perform particularly well on system with low RAM. Even though a potential fix was provided in issue #5 , the problem still occurs from time to time. If a timeout is provided, a user of TcUnit-Runner can implement a `retry(x) {}` step in Jenkins to keep the butler happy.

* During testing we are now monitoring the AdsState for all PLC ports that are used in the solution. If any of them is not `AdsState.Run` the process is terminated. TcUnit-Runner prepares an environment where the AdsState should be `AdsState.Run` and if it is not the case, this is an indication for a TwinCAT issue (no license activated, PLC Exception).

I tested the implementation with my setup, but more testing on your side, @sagatowski would be appreciated.