### PR TITLE
Implement timeout (or react to exceptions), solves issue #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ to read the:
 The software is developed using Visual Studio 2013 community edition. You will also need to:
 1. Download the [Visual Studio Installer Projects Extension](https://marketplace.visualstudio.com/items?itemName=UnniRavindranathan-MSFT.MicrosoftVisualStudio2013InstallerProjects)
 for VS2013. The installation of this extension can be done prior to opening the project.
-2. Install [log4net](https://logging.apache.org/log4net/). Open the project with VS2013. Go to `TOOLS->NuGet Package Manager->Package Manager Console`. In the console enter `Install-Package log4net -Version 2.0.8`.
+2. Install [log4net](https://logging.apache.org/log4net/). Open the project with VS2013. Go to `TOOLS->NuGet Package Manager->Package Manager Console`. In the console enter `Install-Package log4net -Version 2.0.12`.
 3. Install [Beckhoff.TwinCAT.Ads](https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_adsnetref/index.html&id=). Open the project with VS2013. Go to `TOOLS->NuGet Package Manager->Package Manager Console`. In the console enter `Install-Package Beckhoff.TwinCAT.Ads -Version 4.4.10`.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ The software is developed using Visual Studio 2013 community edition. You will a
 1. Download the [Visual Studio Installer Projects Extension](https://marketplace.visualstudio.com/items?itemName=UnniRavindranathan-MSFT.MicrosoftVisualStudio2013InstallerProjects)
 for VS2013. The installation of this extension can be done prior to opening the project.
 2. Install [log4net](https://logging.apache.org/log4net/). Open the project with VS2013. Go to `TOOLS->NuGet Package Manager->Package Manager Console`. In the console enter `Install-Package log4net -Version 2.0.8`.
+3. Install [Beckhoff.TwinCAT.Ads](https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_adsnetref/index.html&id=). Open the project with VS2013. Go to `TOOLS->NuGet Package Manager->Package Manager Console`. In the console enter `Install-Package Beckhoff.TwinCAT.Ads -Version 4.4.10`.

--- a/TcUnit-Runner/Beckhoff.TwinCAT.Ads_LICENSE
+++ b/TcUnit-Runner/Beckhoff.TwinCAT.Ads_LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -25,6 +25,7 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_NOT_POSSIBLE_TO_PARSE_REAL_TIME_TASK_XML_DATA = 14;
         public const int RETURN_FAILED_FINDING_DEFINED_UNIT_TEST_TASK_IN_TWINCAT_PROJECT = 15;
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
+        public const int RETURN_TIMEOUT = 17;
 
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";

--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -26,6 +26,7 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_FAILED_FINDING_DEFINED_UNIT_TEST_TASK_IN_TWINCAT_PROJECT = 15;
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
         public const int RETURN_TIMEOUT = 17;
+        public const int RETURN_INVALID_ADSSTATE = 18;
 
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -61,7 +61,7 @@ namespace TcUnit.TcUnit_Runner
                 .Add("v=|VisualStudioSolutionFilePath=", "The full path to the TwinCAT project (sln-file)", v => VisualStudioSolutionFilePath = v)
                 .Add("t=|TcUnitTaskName=", "[OPTIONAL] The name of the task running TcUnit defined under \"Tasks\"", t => TcUnitTaskName = t)
                 .Add("a=|AmsNetId=", "[OPTIONAL] The AMS NetId of the device of where the project and TcUnit should run", a => AmsNetId = a)
-                .Add("T=|Timeout=", "[OPTIONAL] Timeout the process with an error after X minutes", T => Timeout = T)
+                .Add("Timeout=", "[OPTIONAL] Timeout the process with an error after X minutes", t => Timeout = t)
                 .Add("?|h|help", h => showHelp = h != null);
 
             try

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -344,7 +344,7 @@ namespace TcUnit.TcUnit_Runner
                             log.Error($"ERROR: invalid AdsState {adsState} <> {AdsState.Run}. This could indicate a PLC Exception, terminating ...");
                             Environment.Exit(Constants.RETURN_INVALID_ADSSTATE);
                         }
-                        Console.WriteLine(tcAdsClient.ReadState().AdsState);
+                        log.Debug($"DEBUG: AdsState={adsState}");
                     }
                 }
                 catch (Exception ex)

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -62,7 +62,7 @@ namespace TcUnit.TcUnit_Runner
                 .Add("v=|VisualStudioSolutionFilePath=", "The full path to the TwinCAT project (sln-file)", v => VisualStudioSolutionFilePath = v)
                 .Add("t=|TcUnitTaskName=", "[OPTIONAL] The name of the task running TcUnit defined under \"Tasks\"", t => TcUnitTaskName = t)
                 .Add("a=|AmsNetId=", "[OPTIONAL] The AMS NetId of the device of where the project and TcUnit should run", a => AmsNetId = a)
-                .Add("Timeout=", "[OPTIONAL] Timeout the process with an error after X minutes", t => Timeout = t)
+                .Add("u=|Timeout=", "[OPTIONAL] Timeout the process with an error after X minutes", u => Timeout = u)
                 .Add("w=|TwinCATVersion=", "[OPTIONAL] The TwinCAT version to be used to load the TwinCAT project", w => ForceToThisTwinCATVersion = w)
                 .Add("?|h|help", h => showHelp = h != null);
             try

--- a/TcUnit-Runner/TcUnit-Runner.csproj
+++ b/TcUnit-Runner/TcUnit-Runner.csproj
@@ -69,11 +69,13 @@
     <Reference Include="envdte90a, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/TcUnit-Runner/TcUnit-Runner.csproj
+++ b/TcUnit-Runner/TcUnit-Runner.csproj
@@ -83,6 +83,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="TwinCAT.Ads, Version=4.4.0.0, Culture=neutral, PublicKeyToken=180016cd49e5e8c3, processorArchitecture=MSIL">
+      <HintPath>..\packages\Beckhoff.TwinCAT.Ads.4.4.10\lib\Net40-full\TwinCAT.Ads.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomationInterface.cs" />

--- a/TcUnit-Runner/XmlUtilities.cs
+++ b/TcUnit-Runner/XmlUtilities.cs
@@ -80,5 +80,17 @@ namespace TcUnit.TcUnit_Runner
             }
             return Convert.ToBoolean(attrPinnedVersion.InnerText);
         }
+
+        /// <summary>
+        /// Returns the Port that is used for a PLC node
+        /// </summary>
+        public static int AmsPort(string plcXml)
+        {
+            XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(plcXml);
+
+            XmlNode nodeAdsPort = xmlDoc.SelectSingleNode("/TreeItem/PlcProjectDef/" + "AdsPort");
+            return Convert.ToInt32(nodeAdsPort.InnerText);
+        }
     }
 }

--- a/TcUnit-Runner/packages.config
+++ b/TcUnit-Runner/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.8" targetFramework="net461" />
+  <package id="log4net" version="2.0.12" targetFramework="net451" />
 </packages>

--- a/TcUnit-Runner/packages.config
+++ b/TcUnit-Runner/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Beckhoff.TwinCAT.Ads" version="4.4.10" targetFramework="net451" />
   <package id="log4net" version="2.0.12" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This pull requests solves the issue that is mentioned in issue #10 .

An additional option to specify a timeout for the process is implemented. I observed that the automation interfaces does not perform particularly well on system with low RAM. Even though a potential fix was provided in issue #5 , the problem still occurs from time to time. If a timeout is provided, a user of TcUnit-Runner can implement a retry(x) {} step in Jenkins to keep the butler happy.

During testing we are now monitoring the AdsState for all PLC ports that are used in the solution. If any of them is not AdsState.Run the process is terminated. TcUnit-Runner prepares an environment where the AdsState should be AdsState.Run and if it is not the case, this is an indication for a TwinCAT issue (no license activated, PLC Exception).

I tested the implementation with my setup, but more testing on your side, @sagatowski would be appreciated.