### PR TITLE
Evaluate test-results, logs a summary and exits process with a exitcode depending on test-results.

### DIFF
--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -27,7 +27,8 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
         public const int RETURN_TIMEOUT = 17;
         public const int RETURN_INVALID_ADSSTATE = 18;
-
+        public const int RETURN_TESTS_FAILED = 19;
+        public const int RETURN_ERROR_NO_TEST_RESULTS = 20;
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";
         public const string RT_CONFIG_ROUTE_SETTINGS_SHORTCUT = "TIRR"; // Shortcut for "Real-Time Configuration^Route Settings"

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -429,7 +429,7 @@ namespace TcUnit.TcUnit_Runner
 
             log.Info(testResult.PrintTestResults());
 
-            if (testResult.AllTestsPassed)
+            if (testResult.GetAllTestsPassed())
                 CleanUpAndExitApplication(Constants.RETURN_SUCCESSFULL);
             else
                 CleanUpAndExitApplication(Constants.RETURN_TESTS_FAILED);

--- a/TcUnit-Runner/TcUnitTestResult.cs
+++ b/TcUnit-Runner/TcUnitTestResult.cs
@@ -147,21 +147,27 @@ namespace TcUnit.TcUnit_Runner
             return _numberOfFailedTestCases;
         }
 
-        public bool AllTestsPassed => GetNumberOfTestSuites() > 0 && GetNumberOfTestCases() > 0 && GetNumberOfFailedTestCases() == 0;
+        public bool GetAllTestsPassed()
+        {
+            return GetNumberOfTestSuites() > 0 &&
+                GetNumberOfTestCases() > 0 &&
+                GetNumberOfFailedTestCases() == 0;
+        }
 
         public string PrintTestResults()
         {
             var builder = new StringBuilder((int)(_numberOfTestSuites * _numberOfTestCases * 100));
             builder.Append("\r\n");
-            builder.Append($"Testresults for {_numberOfTestSuites} Testsuite(s) with total {_numberOfTestCases} Testcase(s):\r\n");
+            builder.Append(string.Format(" huhu Testresults for {0} Testsuite(s) with total {1} Testcase(s):\r\n", _numberOfTestSuites, _numberOfTestCases));
             foreach (var suite in _testSuiteResults)
             {
-                builder.Append($"ID={suite.Identity}, Name=\"{suite.Name}\": Tests={suite.NumberOfTests}, Failures={suite.NumberOfFailedTests}.\r\n");
+                builder.Append(string.Format("ID={0}, Name=\"{1}\": Tests={2}, Failures={3}.\r\n", suite.Identity, suite.Name, suite.NumberOfTests, suite.NumberOfFailedTests));
+
                 foreach (var testCaseResult in suite.TestCaseResults)
                 {
-                    builder.Append($"\tTestcase \"{testCaseResult.TestName}\", Assertions={testCaseResult.NumberOfAsserts}, ClassName=\"{testCaseResult.TestClassName}\", Status=\"{testCaseResult.TestStatus}\"");
-                    builder.Append(testCaseResult.WasSuccessful ? ".\r\n" : $" Message=\"{testCaseResult.FailureMessage}\", Type=\"{testCaseResult.AssertType}\".\r\n");
-                   
+                    builder.Append(string.Format("\tTestcase \"{0}\", Assertions={1}, ClassName=\"{2}\", Status=\"{3}\"", testCaseResult.TestName, testCaseResult.NumberOfAsserts, testCaseResult.TestClassName, testCaseResult.TestStatus));
+                    builder.Append(testCaseResult.WasSuccessful ? ".\r\n" :
+                        string.Format(" Message=\"{0}\", Type=\"{1}\".\r\n", testCaseResult.FailureMessage, testCaseResult.AssertType));
                 }
             }
 

--- a/TcUnit-Runner/TcUnitTestResult.cs
+++ b/TcUnit-Runner/TcUnitTestResult.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace TcUnit.TcUnit_Runner
 {
@@ -45,7 +42,7 @@ namespace TcUnit.TcUnit_Runner
             ULINT,
             USINT,
             WORD,
-    
+
             /* Array types */
             Array2D_LREAL,
             Array2D_REAL,
@@ -76,6 +73,7 @@ namespace TcUnit.TcUnit_Runner
             public string FailureMessage;
             public string AssertType;
             public uint NumberOfAsserts;
+            public bool WasSuccessful;
             public TestCaseResult(string testName, string testClassName, string testStatus, string failureMessage, string assertType, uint numberOfAsserts)
             {
                 TestName = testName;
@@ -84,6 +82,7 @@ namespace TcUnit.TcUnit_Runner
                 FailureMessage = failureMessage;
                 AssertType = assertType;
                 NumberOfAsserts = numberOfAsserts;
+                WasSuccessful = !string.IsNullOrEmpty(testStatus) && string.Equals(testStatus, "PASS", System.StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -117,7 +116,7 @@ namespace TcUnit.TcUnit_Runner
             _numberOfSuccessfulTestCases = numberOfSuccessfulTestCases;
             _numberOfFailedTestCases = numberOfFailedTestCases;
         }
-        
+
         IEnumerator<TestSuiteResult> IEnumerable<TestSuiteResult>.GetEnumerator()
         {
             return _testSuiteResults.GetEnumerator();
@@ -137,15 +136,36 @@ namespace TcUnit.TcUnit_Runner
         {
             return _numberOfTestCases;
         }
-        
+
         public uint GetNumberOfSuccessfulTestCases()
         {
             return _numberOfSuccessfulTestCases;
         }
-        
+
         public uint GetNumberOfFailedTestCases()
         {
             return _numberOfFailedTestCases;
+        }
+
+        public bool AllTestsPassed => GetNumberOfTestSuites() > 0 && GetNumberOfTestCases() > 0 && GetNumberOfFailedTestCases() == 0;
+
+        public string PrintTestResults()
+        {
+            var builder = new StringBuilder((int)(_numberOfTestSuites * _numberOfTestCases * 100));
+            builder.Append("\r\n");
+            builder.Append($"Testresults for {_numberOfTestSuites} Testsuite(s) with total {_numberOfTestCases} Testcase(s):\r\n");
+            foreach (var suite in _testSuiteResults)
+            {
+                builder.Append($"ID={suite.Identity}, Name=\"{suite.Name}\": Tests={suite.NumberOfTests}, Failures={suite.NumberOfFailedTests}.\r\n");
+                foreach (var testCaseResult in suite.TestCaseResults)
+                {
+                    builder.Append($"\tTestcase \"{testCaseResult.TestName}\", Assertions={testCaseResult.NumberOfAsserts}, ClassName=\"{testCaseResult.TestClassName}\", Status=\"{testCaseResult.TestStatus}\"");
+                    builder.Append(testCaseResult.WasSuccessful ? ".\r\n" : $" Message=\"{testCaseResult.FailureMessage}\", Type=\"{testCaseResult.AssertType}\".\r\n");
+                   
+                }
+            }
+
+            return builder.ToString();
         }
     }
 }


### PR DESCRIPTION
This PR enables the evaluation of the test-results internally.
Useful if one uses TcUnit-Runner without Jenkins, i.e. GitHub Actions.  
No need for additional steps to report via Junit-XML, i.e. `KyleAure/junit-report-annotations-action`.

```
2021-05-16 13:10:09 - ... got 28 report lines so far.
2021-05-16 13:10:09 - All results from TcUnit obtained
2021-05-16 13:10:19 - Done collecting TC results
2021-05-16 13:10:19 - Writing xUnit XML file to C:\Users\%USERNAME%\private-actions-runner\_work\TcUnitCiTest\TcUnitCiTest\src\TcUnit_xUnit_results.xml
2021-05-16 13:10:19 - 
Testresults for 1 Testsuite(s) with total 2 Testcase(s):
ID=0, Name="PRG_Tests.fbSum_Tests": Tests=2, Failures=1.
	Testcase "TwoPlusTwoEqualsFour", Assertions=1, ClassName="PRG_Tests.fbSum_Tests", Status="PASS".
	Testcase "ZeroPlusZeroEqualsZero", Assertions=1, ClassName="PRG_Tests.fbSum_Tests", Status="FAIL" Message="The calculation is not correct", Type="INT".

2021-05-16 13:10:19 - Closing the Visual Studio Development Tools Environment (DTE)...
2021-05-16 13:10:39 - Exiting application...
Exit code is 19
Error: Process completed with exit code 19.
```