### PR TITLE
Add variant support

### DIFF
--- a/TcUnit-Runner/AutomationInterface.cs
+++ b/TcUnit-Runner/AutomationInterface.cs
@@ -14,7 +14,7 @@ namespace TcUnit.TcUnit_Runner
     /// </summary>
     class AutomationInterface
     {
-        private ITcSysManager10 sysManager = null;
+        private ITcSysManager14 sysManager = null;
         private ITcConfigManager configManager = null;
         private ITcSmTreeItem plcTreeItem = null;
         private ITcSmTreeItem routesTreeItem = null;
@@ -23,7 +23,7 @@ namespace TcUnit.TcUnit_Runner
 
         public AutomationInterface(EnvDTE.Project project)
         {
-            sysManager = (ITcSysManager10)project.Object;
+            sysManager = (ITcSysManager14)project.Object;
             configManager = (ITcConfigManager)sysManager.ConfigurationManager;
             plcTreeItem = sysManager.LookupTreeItem(Constants.PLC_CONFIGURATION_SHORTCUT);
             routesTreeItem = sysManager.LookupTreeItem(Constants.RT_CONFIG_ROUTE_SETTINGS_SHORTCUT);
@@ -35,7 +35,7 @@ namespace TcUnit.TcUnit_Runner
         public AutomationInterface(VisualStudioInstance vsInst) : this(vsInst.GetProject())
         { }
 
-        public ITcSysManager10 ITcSysManager
+        public ITcSysManager14 ITcSysManager
         {
             get
             {

--- a/TcUnit-Runner/AutomationInterface.cs
+++ b/TcUnit-Runner/AutomationInterface.cs
@@ -14,7 +14,7 @@ namespace TcUnit.TcUnit_Runner
     /// </summary>
     class AutomationInterface
     {
-        private ITcSysManager14 sysManager = null;
+        private ITcSysManager10 sysManager = null;
         private ITcConfigManager configManager = null;
         private ITcSmTreeItem plcTreeItem = null;
         private ITcSmTreeItem routesTreeItem = null;
@@ -23,7 +23,7 @@ namespace TcUnit.TcUnit_Runner
 
         public AutomationInterface(EnvDTE.Project project)
         {
-            sysManager = (ITcSysManager14)project.Object;
+            sysManager = (ITcSysManager10)project.Object;
             configManager = (ITcConfigManager)sysManager.ConfigurationManager;
             plcTreeItem = sysManager.LookupTreeItem(Constants.PLC_CONFIGURATION_SHORTCUT);
             routesTreeItem = sysManager.LookupTreeItem(Constants.RT_CONFIG_ROUTE_SETTINGS_SHORTCUT);
@@ -35,7 +35,7 @@ namespace TcUnit.TcUnit_Runner
         public AutomationInterface(VisualStudioInstance vsInst) : this(vsInst.GetProject())
         { }
 
-        public ITcSysManager14 ITcSysManager
+        public ITcSysManager10 ITcSysManager
         {
             get
             {

--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -27,7 +27,7 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
         public const int RETURN_TIMEOUT = 17;
         public const int RETURN_INVALID_ADSSTATE = 18;
-        public const int RETURN_INVALID_VARIANT = 19;
+        public const int RETURN_FAILED_TO_SET_VARIANT = 19;
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";
         public const string RT_CONFIG_ROUTE_SETTINGS_SHORTCUT = "TIRR"; // Shortcut for "Real-Time Configuration^Route Settings"

--- a/TcUnit-Runner/Constants.cs
+++ b/TcUnit-Runner/Constants.cs
@@ -27,7 +27,7 @@ namespace TcUnit.TcUnit_Runner
         public const int RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE = 16;
         public const int RETURN_TIMEOUT = 17;
         public const int RETURN_INVALID_ADSSTATE = 18;
-
+        public const int RETURN_INVALID_VARIANT = 19;
 
         public const string XUNIT_RESULT_FILE_NAME = "TcUnit_xUnit_results.xml";
         public const string RT_CONFIG_ROUTE_SETTINGS_SHORTCUT = "TIRR"; // Shortcut for "Real-Time Configuration^Route Settings"

--- a/TcUnit-Runner/LaunchTcUnit.bat
+++ b/TcUnit-Runner/LaunchTcUnit.bat
@@ -22,8 +22,9 @@ SET TCUNIT_TASK_NAME=
 SET TCUNIT_AMSNETID=
 SET TCUNIT_TCVERSION_TO_USE=
 SET TCUNIT_TIMEOUT=
+SET TCUNIT_VARIANT=
 
-CALL :Process_Parameters %1, %2, %3, %4, %5, %6, %7, %8
+CALL :Process_Parameters %*
 
 rem Create parameter call to TcUnit-Runner
 SET TCUNIT_RUNNER_PARAMETERS=
@@ -38,6 +39,9 @@ IF DEFINED TCUNIT_TCVERSION_TO_USE (
 )
 IF DEFINED TCUNIT_TIMEOUT (
     SET TCUNIT_RUNNER_PARAMETERS=%TCUNIT_RUNNER_PARAMETERS% --Timeout=%TCUNIT_TIMEOUT%
+)
+IF DEFINED TCUNIT_VARIANT (
+    SET TCUNIT_RUNNER_PARAMETERS=%TCUNIT_RUNNER_PARAMETERS% --Variant=%TCUNIT_VARIANT%
 )
 
 SET TCUNIT_RUNNER_EXECUTABLE_COMPLETE_PATH=%TCUNIT_RUNNER_INSTALL_DIRECTORY%\TcUnit-Runner.exe
@@ -72,6 +76,11 @@ IF NOT DEFINED TCUNIT_TIMEOUT (
     echo Timeout has been provided, using [min]: %TCUNIT_TIMEOUT%
 )
 
+IF NOT DEFINED TCUNIT_VARIANT (
+    echo Variant not provided.
+) ELSE (
+    echo Variant has been provided: %TCUNIT_VARIANT%
+)
 
 rem Find the visual studio solution file.
 FOR /r %%i IN (*.sln) DO (
@@ -98,111 +107,69 @@ EXIT /B %errorlevel%
 rem This function process the parameters 
 :Process_Parameters
 
-rem First parameter
-IF "%~1" == "-t" (
-    SET TCUNIT_TASK_NAME=%2
-)
-IF "%~1" == "-T" (
-    SET TCUNIT_TASK_NAME=%2
-)
-IF "%~1" == "-a" (
-    SET TCUNIT_AMSNETID=%2
-)
-IF "%~1" == "-A" (
-    SET TCUNIT_AMSNETID=%2
-)
-IF "%~1" == "-w" (
-    SET TCUNIT_TCVERSION_TO_USE=%2
-)
-IF "%~1" == "-W" (
-    SET TCUNIT_TCVERSION_TO_USE=%2
-)
-IF "%~1" == "-u" (
-    SET TCUNIT_TIMEOUT=%2
-)
-IF "%~1" == "-U" (
-    SET TCUNIT_TIMEOUT=%2
-)
-
-rem Second parameter
-IF "%~3" == "-t" (
-    SET TCUNIT_TASK_NAME=%4
-)
-IF "%~3" == "-T" (
-    SET TCUNIT_TASK_NAME=%4
-)
-IF "%~3" == "-a" (
-    SET TCUNIT_AMSNETID=%4
-)
-IF "%~3" == "-A" (
-    SET TCUNIT_AMSNETID=%4
-)
-IF "%~3" == "-w" (
-    SET TCUNIT_TCVERSION_TO_USE=%4
-)
-IF "%~3" == "-W" (
-    SET TCUNIT_TCVERSION_TO_USE=%4
-)
-IF "%~3" == "-u" (
-    SET TCUNIT_TIMEOUT=%4
-)
-IF "%~3" == "-U" (
-    SET TCUNIT_TIMEOUT=%4
-)
-
-rem Third parameter
-IF "%~5" == "-t" (
-    SET TCUNIT_TASK_NAME=%6
-)
-IF "%~5" == "-T" (
-    SET TCUNIT_TASK_NAME=%6
-)
-IF "%~5" == "-a" (
-    SET TCUNIT_AMSNETID=%6
-)
-IF "%~5" == "-A" (
-    SET TCUNIT_AMSNETID=%6
-)
-IF "%~5" == "-w" (
-    SET TCUNIT_TCVERSION_TO_USE=%6
-)
-IF "%~5" == "-W" (
-    SET TCUNIT_TCVERSION_TO_USE=%6
-)
-IF "%~5" == "-u" (
-    SET TCUNIT_TIMEOUT=%6
-)
-IF "%~5" == "-U" (
-    SET TCUNIT_TIMEOUT=%6
+rem flag exists
+IF NOT [%1]==[] (
+	rem parameter exists
+	IF NOT [%2]==[] (
+		rem store parameter
+		IF "%~1" == "-t" (
+			SET TCUNIT_TASK_NAME=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-T" (
+			SET TCUNIT_TASK_NAME=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-a" (
+			SET TCUNIT_AMSNETID=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-A" (
+			SET TCUNIT_AMSNETID=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-w" (
+			SET TCUNIT_TCVERSION_TO_USE=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-W" (
+			SET TCUNIT_TCVERSION_TO_USE=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-u" (
+			SET TCUNIT_TIMEOUT=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-U" (
+			SET TCUNIT_TIMEOUT=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-r" (
+			SET TCUNIT_VARIANT=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		IF "%~1" == "-R" (
+			SET TCUNIT_VARIANT=%2
+			SHIFT & SHIFT
+			GOTO :Process_Parameters
+		)
+		
+		rem No flag found, ignore and try next parameter
+		SHIFT
+		GOTO :Process_Parameters
+	)
 )
 
-rem Fourth parameter
-IF "%~7" == "-t" (
-    SET TCUNIT_TASK_NAME=%8
-)
-IF "%~7" == "-T" (
-    SET TCUNIT_TASK_NAME=%8
-)
-IF "%~7" == "-a" (
-    SET TCUNIT_AMSNETID=%8
-)
-IF "%~7" == "-A" (
-    SET TCUNIT_AMSNETID=%8
-)
-IF "%~7" == "-w" (
-    SET TCUNIT_TCVERSION_TO_USE=%8
-)
-IF "%~7" == "-W" (
-    SET TCUNIT_TCVERSION_TO_USE=%8
-)
-IF "%~7" == "-u" (
-    SET TCUNIT_TIMEOUT=%8
-)
-IF "%~7" == "-U" (
-    SET TCUNIT_TIMEOUT=%8
-)
-
-
+rem no parameter pairs anymore => return
 GOTO:EOF
 
 :Exit

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -14,16 +14,17 @@
 * 4. Load the solution
 * 5. Check that the solution has at least one PLC-project
 * 6. Clean the solution
-* 7. Build the solution. Make sure that build was successful.
-* 8. Set target NetId to 127.0.0.1.1.1
-* 9. If user has provided 'TcUnitTaskName', iterate all PLC projects and do:
-*     9.1. Find the 'TcUnitTaskName', and set the <AutoStart> to TRUE and <Disabled> to FALSE for the TIRT^ of the TASK
-*     9.2. Iterate the rest of the tasks (if there are any), and set the <AutoStart> to FALSE and <Disabled> to TRUE for the TIRT^ of the task
-* 10. Enable boot project autostart for all PLC projects
-* 11. Activate configuration
-* 12. Restart TwinCAT
-* 13. Wait until TcUnit has reported all results and collect all results
-* 14. Write all results to xUnit compatible XML-file
+* 7. Set variant if provided
+* 8. Build the solution. Make sure that build was successful.
+* 9. Set target NetId to 127.0.0.1.1.1
+* 10. If user has provided 'TcUnitTaskName', iterate all PLC projects and do:
+*     10.1. Find the 'TcUnitTaskName', and set the <AutoStart> to TRUE and <Disabled> to FALSE for the TIRT^ of the TASK
+*     10.2. Iterate the rest of the tasks (if there are any), and set the <AutoStart> to FALSE and <Disabled> to TRUE for the TIRT^ of the task
+* 11. Enable boot project autostart for all PLC projects
+* 12. Activate configuration
+* 13. Restart TwinCAT
+* 14. Wait until TcUnit has reported all results and collect all results
+* 15. Write all results to xUnit compatible XML-file
 */
 
 using EnvDTE80;
@@ -49,6 +50,7 @@ namespace TcUnit.TcUnit_Runner
         private static string VisualStudioSolutionFilePath = null;
         private static string TwinCATProjectFilePath = null;
         private static string TcUnitTaskName = null;
+        private static string Variant = null;
         private static string ForceToThisTwinCATVersion = null;
         private static string AmsNetId = null;
         private static List<int> AmsPorts = new List<int>();
@@ -68,6 +70,7 @@ namespace TcUnit.TcUnit_Runner
             OptionSet options = new OptionSet()
                 .Add("v=|VisualStudioSolutionFilePath=", "The full path to the TwinCAT project (sln-file)", v => VisualStudioSolutionFilePath = v)
                 .Add("t=|TcUnitTaskName=", "[OPTIONAL] The name of the task running TcUnit defined under \"Tasks\"", t => TcUnitTaskName = t)
+                .Add("r=|Variant=", "[OPTIONAL] The name of the variant to use.", var => Variant = var)
                 .Add("a=|AmsNetId=", "[OPTIONAL] The AMS NetId of the device of where the project and TcUnit should run", a => AmsNetId = a)
                 .Add("w=|TcVersion=", "[OPTIONAL] The TwinCAT version to be used to load the TwinCAT project", w => ForceToThisTwinCATVersion = w)
                 .Add("u=|Timeout=", "[OPTIONAL] Timeout the process with an error after X minutes", u => Timeout = u)
@@ -270,6 +273,22 @@ namespace TcUnit.TcUnit_Runner
                 {
                     log.Error("The number of tasks is not equal to 1 (one). Found " + realTimeTasksTreeItem.ChildCount.ToString() + " number of tasks. Please provide which task is the TcUnit task");
                     CleanUpAndExitApplication(Constants.RETURN_TASK_COUNT_NOT_EQUAL_TO_ONE);
+                }
+            }
+
+            /* Select variant if provided as parameter
+             */
+            if (!String.IsNullOrEmpty(Variant))
+            {
+                try
+                {
+                    automationInterface.ITcSysManager.CurrentProjectVariant = Variant;
+                    log.Info("Variant selected with name: " + Variant);
+                }
+                catch
+                {
+                    log.Error("Unable to set variant: " + Variant + ". Please provide an existing variant from the project.");
+                    CleanUpAndExitApplication(Constants.RETURN_INVALID_VARIANT);
                 }
             }
 

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -280,15 +280,25 @@ namespace TcUnit.TcUnit_Runner
              */
             if (!String.IsNullOrEmpty(Variant))
             {
-                try
+                if (Utilities.CompareVersionStrings("3.1.4024.0", vsInstance.GetLoadedTcVersion()))
                 {
-                    automationInterface.ITcSysManager.CurrentProjectVariant = Variant;
-                    log.Info("Variant selected with name: " + Variant);
+                    try
+                    {
+                        //Using newer version of ITcSysManager to be able to set variant
+                        ITcSysManager14 sysManager = (ITcSysManager14)vsInstance.GetProject().Object;
+                        sysManager.CurrentProjectVariant = Variant;
+                        log.Info("Variant selected with name: " + Variant);
+                    }
+                    catch
+                    {
+                        log.Error("Unable to set variant: " + Variant + ". Please provide an existing variant from the project.");
+                        CleanUpAndExitApplication(Constants.RETURN_FAILED_TO_SET_VARIANT);
+                    }
                 }
-                catch
+                else
                 {
-                    log.Error("Unable to set variant: " + Variant + ". Please provide an existing variant from the project.");
-                    CleanUpAndExitApplication(Constants.RETURN_INVALID_VARIANT);
+                    log.Error("Variants are only supported from Tc3.1.4024.0 or higher.");
+                    CleanUpAndExitApplication(Constants.RETURN_FAILED_TO_SET_VARIANT);
                 }
             }
 

--- a/TcUnit-Runner/TcUnit-Runner.csproj
+++ b/TcUnit-Runner/TcUnit-Runner.csproj
@@ -130,17 +130,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="TCatSysManagerLib">
-      <Guid>{3C49D6C3-93DC-11D0-B162-00A0248C244B}</Guid>
-      <VersionMajor>3</VersionMajor>
-      <VersionMinor>2</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5.1">
       <Visible>False</Visible>
       <ProductName>Microsoft .NET Framework 4.5.1 %28x86 and x64%29</ProductName>
@@ -156,6 +145,20 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
+  </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="TCatSysManagerLib">
+      <Guid>{3C49D6C3-93DC-11D0-B162-00A0248C244B}</Guid>
+      <VersionMajor>3</VersionMajor>
+      <VersionMinor>3</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TcUnit-Runner/Utilities.cs
+++ b/TcUnit-Runner/Utilities.cs
@@ -120,5 +120,17 @@ namespace TcUnit.TcUnit_Runner
 
             return String.Empty;
         }
+
+        /// <summary>
+        /// Compare two version strings to see if Version >= baseVersion
+        /// </summary>
+        /// <returns>True if Version >= baseVersion</returns>
+        public static bool CompareVersionStrings(string baseVersion, string Version)
+        {
+            var vBase = new Version(baseVersion);
+            var vComp = new Version(Version);
+
+            return vBase.CompareTo(vComp) <= 0;
+        }
     }
 }

--- a/TcUnit-Runner/VisualStudioInstance.cs
+++ b/TcUnit-Runner/VisualStudioInstance.cs
@@ -30,6 +30,7 @@ namespace TcUnit.TcUnit_Runner
         private string @filePath = null;
         private string vsVersion = null;
         private string tcVersion = null;
+        private string tcVersionLoaded = null;
         private string forceToThisTwinCatVersion = null;
         private EnvDTE80.DTE2 dte = null;
         private Type type = null;
@@ -198,7 +199,8 @@ namespace TcUnit.TcUnit_Runner
                throw new Exception("Wrong configuration for this TwinCAT version");
             }
 
-            // Log the Version which will be loaded
+            // Log and save the Version which will be loaded
+            tcVersionLoaded = remoteManager.Version;
             log.Info("Using the TwinCAT remote manager to load TwinCAT version '" + remoteManager.Version + "'...");
         }
 
@@ -384,6 +386,11 @@ namespace TcUnit.TcUnit_Runner
         public string GetVisualStudioVersion()
         {
             return this.vsVersion;
+        }
+
+        public string GetLoadedTcVersion()
+        {
+            return tcVersionLoaded;
         }
 
         public EnvDTE.Project GetProject()


### PR DESCRIPTION
Feature for setting a variant with an optional parameter -r (--Variant). 
If a variant isn't provided, TwinCat uses the latest selected variant by default (stored outside the project?).

As ITcSysManager14 is used instead of ITcSysManager10, suggestion are welcome to keep it backwards compatible with older versions. 