### PR TITLE
Fixes #28: BuildSolution Hangs after CleanSolution

### DIFF
--- a/TcUnit-Runner/Properties/AssemblyInfo.cs
+++ b/TcUnit-Runner/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.4.0")]
-[assembly: AssemblyFileVersion("0.9.4.0")]
+[assembly: AssemblyVersion("0.9.5.0")]
+[assembly: AssemblyFileVersion("0.9.5.0")]

--- a/TcUnit-Runner/VisualStudioInstance.cs
+++ b/TcUnit-Runner/VisualStudioInstance.cs
@@ -34,6 +34,7 @@ namespace TcUnit.TcUnit_Runner
         private EnvDTE80.DTE2 dte = null;
         private Type type = null;
         private EnvDTE.Solution visualStudioSolution = null;
+        private EnvDTE.SolutionBuild solutionBuild = null;
         EnvDTE.Project pro = null;
         ILog log = LogManager.GetLogger("TcUnit-Runner");
         private bool loaded = false;
@@ -372,6 +373,7 @@ namespace TcUnit.TcUnit_Runner
         private void LoadSolution(string filePath)
         {
             visualStudioSolution = dte.Solution;
+            solutionBuild = dte.Solution.SolutionBuild;
             visualStudioSolution.Open(@filePath);
         }
 
@@ -398,13 +400,15 @@ namespace TcUnit.TcUnit_Runner
 
         public void CleanSolution()
         {
-            visualStudioSolution.SolutionBuild.Clean(true);
+            Thread.Sleep(1000);
+            solutionBuild.Clean(true);
         }
 
         public void BuildSolution()
         {
-            visualStudioSolution.SolutionBuild.Build(false);
-            SpinWait.SpinUntil(() => visualStudioSolution.SolutionBuild.BuildState == EnvDTE.vsBuildState.vsBuildStateDone);
+            Thread.Sleep(1000);
+            solutionBuild.Build(false);
+            SpinWait.SpinUntil(() => solutionBuild.BuildState == EnvDTE.vsBuildState.vsBuildStateDone);
         }
 
         public ErrorItems GetErrorItems()


### PR DESCRIPTION
This PR fixes issue #28 (and closed #5).

Caching the `EnvDTE.SolutionBuild` object made the build process much more stable/reliable.
Adding a additional "cool down", aka `Thread.Sleep`, should also improve
the process.

We had this issue only on our build pipeline (self-hosted GitHub runner with `TcXaeShell` on a VM), not locally on the dev-machine, which was also mentioned in the issues.

