### PR TITLE
Find first .tsproj even if it has a subdir path in .sln

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,5 +359,7 @@ MigrationBackup/
 .ionide/
 
 # Fody - auto-generated XML schema
-FodyWeavers.xsd.vscode
+FodyWeavers.xsd
+
+# VS Code - auto generated folder, remove if we want this
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -359,4 +359,5 @@ MigrationBackup/
 .ionide/
 
 # Fody - auto-generated XML schema
-FodyWeavers.xsd
+FodyWeavers.xsd.vscode
+.vscode/

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -151,9 +151,9 @@ namespace TcUnit.TcUnit_Runner
             {
                 vsInstance.LoadSolution();
             }
-            catch
+            catch (Exception e)
             {
-                log.Error("ERROR: Error loading the solution. Try to open it manually and make sure it's possible to open and that all dependencies are working");
+                log.Error("ERROR: Error loading the solution. Try to open it manually and make sure it's possible to open and that all dependencies are working.\n" + e.ToString());
                 CleanUpAndExitApplication(Constants.RETURN_ERROR_LOADING_VISUAL_STUDIO_SOLUTION);
             }
 

--- a/TcUnit-Runner/VisualStudioInstance.cs
+++ b/TcUnit-Runner/VisualStudioInstance.cs
@@ -40,7 +40,7 @@ namespace TcUnit.TcUnit_Runner
 
         public VisualStudioInstance(string @visualStudioSolutionFilePath, string twinCatVersion, string forceToThisTwinCatVersion)
         {
-            this.filePath = visualStudioSolutionFilePath;
+            this.filePath = Path.GetFullPath(visualStudioSolutionFilePath);
             string visualStudioVersion = VisualStudioTools.FindVisualStudioVersion(@filePath);
             this.vsVersion = visualStudioVersion;
             this.tcVersion = twinCatVersion;
@@ -90,6 +90,7 @@ namespace TcUnit.TcUnit_Runner
         {
             if (!String.IsNullOrEmpty(@filePath))
             {
+                log.Info("Loading: " + @filePath);
                 LoadSolution(@filePath);
                 LoadProject();
                 loaded = true;
@@ -233,12 +234,14 @@ namespace TcUnit.TcUnit_Runner
                 return VisualStudioProgId;
             } else
             {
-                List<string> VisualStudioProgIds = new List<string>();
-                VisualStudioProgIds.Add("VisualStudio.DTE.16.0"); // VS2019
-                VisualStudioProgIds.Add("TcXaeShell.DTE.15.0"); // TcXaeShell (VS2017)
-                VisualStudioProgIds.Add("VisualStudio.DTE.15.0"); // VS2017
-                VisualStudioProgIds.Add("VisualStudio.DTE.14.0"); // VS2015
-                VisualStudioProgIds.Add("VisualStudio.DTE.12.0"); // VS2013
+                List<string> VisualStudioProgIds = new List<string>
+                {
+                    "TcXaeShell.DTE.15.0", // TcXaeShell (VS2017)
+                    "VisualStudio.DTE.16.0", // VS2019
+                    "VisualStudio.DTE.15.0", // VS2017
+                    "VisualStudio.DTE.14.0", // VS2015
+                    "VisualStudio.DTE.12.0" // VS2013
+                };
 
                 foreach (string visualStudioProgIdent in VisualStudioProgIds)
                 {
@@ -268,9 +271,9 @@ namespace TcUnit.TcUnit_Runner
                 dte = (EnvDTE80.DTE2)System.Activator.CreateInstance(type);
                 log.Info("...SUCCESSFUL!");
                 return true;
-            } catch
+            } catch (Exception e)
             {
-                log.Info("...FAILED!");
+                log.Info($"...FAILED! ({e.Message})");
                 return false;
             }
         }


### PR DESCRIPTION
TcUnit runner did not find my .tsproj when I had this line in the .sln. This PR fixes that and keeps the old behavior (if necessary, didn't want to touch that)

```
Project("{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}") = "CatFish Usermode", "CatFish Usermode\CatFish Usermode.tsproj", "{C05C6525-F818-434B-B8BD-AB198DB4ED7A}"
EndProject
```