### PR TITLE
FindTwinCATProjectFile to ignore standalone projects tspproj file

### DIFF
--- a/TcUnit-Runner/TcFileUtilities.cs
+++ b/TcUnit-Runner/TcFileUtilities.cs
@@ -64,6 +64,7 @@ namespace TcUnit.TcUnit_Runner
             {
                 if (line.StartsWith("Project"))
                 {
+                    if (line.Contains(".tspproj")) continue;
                     tcProjectFile = Utilities.GetUntilOrEmpty(line, ".tsproj");
                     break;
                 }


### PR DESCRIPTION
added an extra condition to ignore the standalone project file ".tspproj".
This is only required if solution contains both a standalone and a XAE project.