### PR TITLE
Proposal: Adding Plugin / hook system feature

### DIFF
--- a/TcUnit-Runner-PluginManager-Test/PluginOptionsTests.cs
+++ b/TcUnit-Runner-PluginManager-Test/PluginOptionsTests.cs
@@ -1,0 +1,52 @@
+﻿using log4net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Xml;
+using TcUnit.TcUnit_Runner.PluginManager;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit_Runner_PluginManager_Test
+{
+    [TestClass]
+    public class PluginOptionsTests
+    {
+
+        private static ILog log = LogManager.GetLogger("TcUnit-Runner-PluginManager-Test");
+        [TestMethod]
+        public void ShouldSuccessfullyLoadOptionsFromFile()
+        {
+            PluginLoader sut = new PluginLoader(log);
+            sut.LoadOptions("test-files/.TcUnitRunner");
+            Assert.AreEqual(sut.Options.Options.ChildNodes.Count, 2);
+        }
+
+        [TestMethod]
+        public void ShouldReturnNodeWithNameTestPlugin()
+        {
+            PluginLoader sut = new PluginLoader(log);
+            sut.LoadOptions("test-files/.TcUnitRunner");
+            var actual = sut.Options.GetPluginNodeByAttributeName("TestPlugin");
+            Assert.IsNotNull(actual);
+        }
+
+        [TestMethod]
+        public void ShouldReturnNodeValueWithNameTestNode()
+        {
+            PluginLoader sut = new PluginLoader(log);
+            sut.LoadOptions("test-files/.TcUnitRunner");
+            var node = sut.Options.GetPluginNodeByAttributeName("TestPlugin");
+            var actual = node.GetPluginNodeValueByName("TestNode");
+            Assert.IsNotNull(actual);
+            Assert.AreEqual("test-value", actual);
+        }
+
+        [TestMethod]
+        public void ShouldReturnAttributeValuePluginsDir()
+        {
+            PluginLoader sut = new PluginLoader(log);
+            sut.LoadOptions("test-files/.TcUnitRunner");
+            var actual = sut.Options.GetPluginsDirectory();
+            Assert.IsNotNull(actual);
+            Assert.AreEqual("./plugins", actual);
+        }
+    }
+}

--- a/TcUnit-Runner-PluginManager-Test/Properties/AssemblyInfo.cs
+++ b/TcUnit-Runner-PluginManager-Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("TcUnit-Runner-PluginManager-T")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TcUnit-Runner-PluginManager-T")]
+[assembly: AssemblyCopyright("Copyright © 2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("e985d732-a453-4d3e-a99f-52d368203ae8")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TcUnit-Runner-PluginManager-Test/TcUnit-Runner-PluginManager-Test.csproj
+++ b/TcUnit-Runner-PluginManager-Test/TcUnit-Runner-PluginManager-Test.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E985D732-A453-4D3E-A99F-52D368203AE8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TcUnit_Runner_PluginManager_Test</RootNamespace>
+    <AssemblyName>TcUnit_Runner_PluginManager_Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=2.0.14.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.XML" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PluginOptionsTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TcUnit-Runner-PluginManager\TcUnit-Runner-PluginManager.csproj">
+      <Project>{fec3d0d8-4291-42dc-92ed-3c9da5af55d0}</Project>
+      <Name>TcUnit-Runner-PluginManager</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="test-files\.TcUnitRunner">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TcUnit-Runner-PluginManager-Test/test-files/.TcUnitRunner
+++ b/TcUnit-Runner-PluginManager-Test/test-files/.TcUnitRunner
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<TcUnitRunner>
+	<Plugins directory="./plugins">
+		<Plugin name = "TestPlugin">
+			<TestNode>test-value</TestNode>
+		</Plugin>
+	</Plugins>
+</TcUnitRunner>

--- a/TcUnit-Runner-PluginManager/Constants.cs
+++ b/TcUnit-Runner-PluginManager/Constants.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TcUnit.TcUnit_Runner.PluginManager
+{
+    public static class Constants
+    {
+        /// <summary>
+        /// The directory to load all plugins from.
+        /// Currently, subdirectory where TcUnit-Runner.exe is located.
+        /// </summary>
+        public const string PLUGINS_DIR = ".\\plugins";
+        public const string XML_PLUGINS_OPTIONS = ".TcUnitRunner";
+    }
+}

--- a/TcUnit-Runner-PluginManager/IPluginLoader.cs
+++ b/TcUnit-Runner-PluginManager/IPluginLoader.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+
+namespace TcUnit.TcUnit_Runner.PluginManager
+{
+    internal interface IPluginLoader
+    {
+        int RunAfterSolutionLoadedHooks(EnvDTE.Project project);
+        int RunBeforeBuildHooks();
+        int RunAfterBuildHooks();
+        int RunBeforeActivateConfigurationHooks();
+        int RunAfterRunningTestsHooks();
+
+        /// <summary>
+        /// Load the plugin options.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        void LoadOptions(string path = Constants.XML_PLUGINS_OPTIONS);
+    }
+}

--- a/TcUnit-Runner-PluginManager/Options/Extenstions.cs
+++ b/TcUnit-Runner-PluginManager/Options/Extenstions.cs
@@ -1,0 +1,23 @@
+﻿using System.Xml;
+using System.Xml.Linq;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Options
+{
+    public static class Extensions
+    {
+        public static XmlNode GetPluginNodeByAttributeName(this PluginOptions pluginOptions, string name)
+        {
+            return pluginOptions.Options.SelectSingleNode(string.Format("TcUnitRunner/Plugins/Plugin[@name='{0}']", name));
+        }
+        public static string GetPluginNodeValueByName(this XmlNode node, string name)
+        {
+            var foundNode = node.SelectSingleNode(string.Format("{0}", name));
+            return foundNode != null ? foundNode.InnerText : string.Empty;
+        }
+        public static string GetPluginsDirectory(this PluginOptions pluginOptions)
+{
+          var node = pluginOptions.Options.SelectSingleNode("TcUnitRunner/Plugins/@directory");
+            return node != null ? node.Value : string.Empty;
+        }
+    }
+}

--- a/TcUnit-Runner-PluginManager/Options/PluginOptions.cs
+++ b/TcUnit-Runner-PluginManager/Options/PluginOptions.cs
@@ -1,0 +1,47 @@
+﻿using log4net;
+using System;
+using System.IO;
+using System.Xml;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Options
+{
+    public class PluginOptions
+    {
+
+        private XmlDocument _options;
+        public XmlDocument Options { get { return _options; } }
+
+        private PluginOptions(XmlDocument xmlDoc)
+        {
+            _options = xmlDoc;
+        }
+
+        /// <summary>
+        /// Load all options for plugins from a XML file.
+        /// </summary>
+        /// <param name="xmlOptionsFilePath"></param>
+        /// <returns></returns>
+        public static PluginOptions LoadPluginOptions(ILog log, string xmlOptionsFilePath)
+        {
+            try
+            {
+                var fi = new FileInfo(Path.GetFullPath(xmlOptionsFilePath));
+
+                if (!fi.Exists)
+                {
+                    log.Warn(string.Format("Plugin configuration file doesn't exist: {0}", fi.FullName));
+                }
+
+                var xmlDoc = new XmlDocument();
+                xmlDoc.Load(fi.FullName);
+                return new PluginOptions(xmlDoc);
+            }
+             catch (Exception ex)
+            {
+                log.Error("Error loading plugin options", ex);
+            }
+
+            return new PluginOptions(new XmlDocument());
+        }
+    }
+}

--- a/TcUnit-Runner-PluginManager/PluginLoader.cs
+++ b/TcUnit-Runner-PluginManager/PluginLoader.cs
@@ -1,0 +1,132 @@
+﻿using log4net;
+using log4net.Plugin;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.IO;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+using TcUnit.TcUnit_Runner.PluginManager.Plugins;
+
+namespace TcUnit.TcUnit_Runner.PluginManager
+{
+    public class PluginLoader : IPluginLoader
+    {
+        [ImportMany(typeof(IAfterSolutionLoadedHook))]
+        private Lazy<IAfterSolutionLoadedHook>[] _afterSolutionLoadedHooks;
+        [ImportMany(typeof(IBeforeBuildHook))]
+        private Lazy<IBeforeBuildHook>[] _beforeBuildHooks;
+        [ImportMany(typeof(IAfterBuildHook))]
+        private Lazy<IAfterBuildHook>[] _afterBuildHooks;
+        [ImportMany(typeof(IBeforeActivateConfigurationHook))]
+        private Lazy<IBeforeActivateConfigurationHook>[] _beforeActivateConfigurationHooks;
+        [ImportMany(typeof(IAfterRunningTestsHook))]
+        private Lazy<IAfterRunningTestsHook>[] _afterRunningTestsHooks;
+
+        private ILog _log;
+
+        private PluginOptions _pluginOptions;
+
+        public PluginLoader(ILog log)
+        {
+            _log = log;
+        }
+
+        public void LoadOptions(string path = Constants.XML_PLUGINS_OPTIONS)
+        {
+            _log.Info(string.Format("Loading options for plugins from '{0}'", path));
+            _pluginOptions = PluginOptions.LoadPluginOptions(_log, path);
+        }
+        public PluginOptions Options { get { return _pluginOptions; } }
+
+        public int RunAfterBuildHooks()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int RunAfterRunningTestsHooks()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int RunAfterSolutionLoadedHooks(EnvDTE.Project project)
+        {
+            if (_afterSolutionLoadedHooks == null)
+            {
+                _log.Info("AfterSolutionLoaded: no hooks registered");
+                return 0;
+            }
+
+            foreach(var lazyHook in _afterSolutionLoadedHooks)
+            {
+                var hook = lazyHook.Value;
+                _log.Info(string.Format("AfterSolutionLoaded: Running plugin {0} ...", hook.Name));
+                var result = hook.Run(project, _log, Options);
+                if(result < 0)
+                {
+                    _log.Error(string.Format("Plugin {0} failed with exit code: {1}", hook.Name, result));
+                    return result;
+                }
+            }
+
+            return 0;
+        }
+
+        public int RunBeforeActivateConfigurationHooks()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int RunBeforeBuildHooks()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Load()
+        {
+            try
+            {
+                var di = GetPluginsDirectory(Options);
+                if (!di.Exists)
+                {
+                    throw new DirectoryNotFoundException(di.FullName);
+                }
+                var catalog = new AggregateCatalog();
+                LoadPluginsFromDirectoryRecursive(catalog, di);
+                var container = new CompositionContainer(catalog);
+                container.ComposeParts(this);
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Error when loading plugins", ex);
+            }
+        }
+
+        private DirectoryInfo GetPluginsDirectory(PluginOptions pluginOptions)
+        {
+            var pluginDir = pluginOptions.GetPluginsDirectory();
+            var di = new DirectoryInfo(string.IsNullOrEmpty(pluginDir) ? Constants.PLUGINS_DIR : pluginDir);
+            return di;
+        }
+
+        private void LoadPluginsFromDirectoryRecursive(AggregateCatalog catalog, DirectoryInfo di)
+        {
+            Queue<string> directories = new Queue<string>();
+            directories.Enqueue(di.FullName);
+            while (directories.Count > 0)
+            {
+                var directory = directories.Dequeue();
+                //Load plugins in this folder
+                var directoryCatalog = new DirectoryCatalog(directory);
+                catalog.Catalogs.Add(directoryCatalog);
+
+                //Add subDirectories to the queue
+                var subDirectories = Directory.GetDirectories(directory);
+                foreach (string subDirectory in subDirectories)
+                {
+                    directories.Enqueue(subDirectory);
+                }
+            }
+        }
+    }
+}

--- a/TcUnit-Runner-PluginManager/Plugins/IAfterBuildHook.cs
+++ b/TcUnit-Runner-PluginManager/Plugins/IAfterBuildHook.cs
@@ -1,0 +1,10 @@
+﻿using log4net;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Plugins
+{
+    public interface IAfterBuildHook : IPluginBase
+    {
+        int Run(EnvDTE.Project project, ILog log, PluginOptions options);
+    }
+}

--- a/TcUnit-Runner-PluginManager/Plugins/IAfterRunningTestsHook.cs
+++ b/TcUnit-Runner-PluginManager/Plugins/IAfterRunningTestsHook.cs
@@ -1,0 +1,10 @@
+﻿using log4net;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Plugins
+{
+    public interface IAfterRunningTestsHook : IPluginBase
+    {
+        int Run(EnvDTE.Project project, ILog log, PluginOptions options);
+    }
+}

--- a/TcUnit-Runner-PluginManager/Plugins/IAfterSolutionLoadedHook.cs
+++ b/TcUnit-Runner-PluginManager/Plugins/IAfterSolutionLoadedHook.cs
@@ -1,0 +1,10 @@
+﻿using log4net;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Plugins
+{
+    public interface IAfterSolutionLoadedHook : IPluginBase
+    {
+        int Run(EnvDTE.Project project, ILog log, PluginOptions options);
+    }
+}

--- a/TcUnit-Runner-PluginManager/Plugins/IBeforeActivateConfigurationHook.cs
+++ b/TcUnit-Runner-PluginManager/Plugins/IBeforeActivateConfigurationHook.cs
@@ -1,0 +1,10 @@
+﻿using log4net;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Plugins
+{
+    public interface IBeforeActivateConfigurationHook : IPluginBase
+    {
+        int Run(EnvDTE.Project project, ILog log, PluginOptions options);
+    }
+}

--- a/TcUnit-Runner-PluginManager/Plugins/IBeforeBuildHook.cs
+++ b/TcUnit-Runner-PluginManager/Plugins/IBeforeBuildHook.cs
@@ -1,0 +1,10 @@
+﻿using log4net;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Plugins
+{
+    public interface IBeforeBuildHook : IPluginBase
+    {
+        int Run(EnvDTE.Project project, ILog log, PluginOptions options);
+    }
+}

--- a/TcUnit-Runner-PluginManager/Plugins/IPluginBase.cs
+++ b/TcUnit-Runner-PluginManager/Plugins/IPluginBase.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+
+namespace TcUnit.TcUnit_Runner.PluginManager.Plugins
+{
+    /// <summary>
+    /// Base interface where all plugins/hooks derive from.
+    /// </summary>
+    public interface IPluginBase
+    {
+        /// <summary>
+        /// Name/identifier for the plugin/hook.
+        /// </summary>
+        string Name { get; }
+    }
+}

--- a/TcUnit-Runner-PluginManager/Properties/AssemblyInfo.cs
+++ b/TcUnit-Runner-PluginManager/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TcUnit-Runner-PluginManager")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TcUnit-Runner-PluginManager")]
+[assembly: AssemblyCopyright("Copyright © 2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fec3d0d8-4291-42dc-92ed-3c9da5af55d0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.0.1.0")]
+[assembly: AssemblyFileVersion("0.0.1.0")]

--- a/TcUnit-Runner-PluginManager/TcUnit-Runner-PluginManager.csproj
+++ b/TcUnit-Runner-PluginManager/TcUnit-Runner-PluginManager.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FEC3D0D8-4291-42DC-92ED-3C9DA5AF55D0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TcUnit_Runner_PluginManager</RootNamespace>
+    <AssemblyName>TcUnit-Runner-PluginManager</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.14\lib\net45\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Constants.cs" />
+    <Compile Include="IPluginLoader.cs" />
+    <Compile Include="Options\Extenstions.cs" />
+    <Compile Include="PluginLoader.cs" />
+    <Compile Include="Options\PluginOptions.cs" />
+    <Compile Include="Plugins\IAfterBuildHook.cs" />
+    <Compile Include="Plugins\IBeforeActivateConfigurationHook.cs" />
+    <Compile Include="Plugins\IAfterRunningTestsHook.cs" />
+    <Compile Include="Plugins\IBeforeBuildHook.cs" />
+    <Compile Include="Plugins\IAfterSolutionLoadedHook.cs" />
+    <Compile Include="Plugins\IPluginBase.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TcUnit-Runner-Test/TcFileUtilitiesTests.cs
+++ b/TcUnit-Runner-Test/TcFileUtilitiesTests.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TcUnit.TcUnit_Runner;
+
+namespace TcUnit_Runner_Test
+{
+    [TestClass]
+    public class TcFileUtilitiesTests
+    {
+        [TestMethod]
+        public void ShouldReturnPathToTsprojFromSlnSuccessfully()
+        {
+            var sln = @".\test-data\Solution.sln";
+
+            var actual = TcFileUtilities.FindTwinCATProjectFile(sln);
+
+            Assert.AreEqual(@".\test-data\TwinCAT Project.tsproj", actual);
+        }
+    }
+}

--- a/TcUnit-Runner-Test/TcUnit-Runner-Test.csproj
+++ b/TcUnit-Runner-Test/TcUnit-Runner-Test.csproj
@@ -51,6 +51,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="TcFileUtilitiesTests.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -59,6 +60,11 @@
       <Project>{107ee0d4-0fd5-42a9-8ba7-58e6fb88bb3d}</Project>
       <Name>TcUnit-Runner</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="test-data\Solution.sln">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/TcUnit-Runner-Test/test-data/Solution.sln
+++ b/TcUnit-Runner-Test/test-data/Solution.sln
@@ -1,0 +1,17 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.34114.132
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{DFBE7525-6864-4E62-8B2E-D530D69D9D96}") = "TwinCAT PLC1", "TwinCAT PLC1\TwinCAT PLC1.tspproj", "{7226783D-3BA6-4225-B25D-4FEF566BFED4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{547EB318-DAAA-4594-87EE-183564F54BBE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4F53F804-3E92-4465-BBD0-3D66918E60A3}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Project("{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}") = "TwinCAT Project", "TwinCAT Project.tsproj", "{2C8E40E8-5888-44D5-8C02-FF326A88CAF0}"
+EndProject
+Global
+EndGlobal

--- a/TcUnit-Runner.sln
+++ b/TcUnit-Runner.sln
@@ -9,6 +9,14 @@ Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "TcUnit-Runner-Setup", "TcUn
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TcUnit-Runner-Test", "TcUnit-Runner-Test\TcUnit-Runner-Test.csproj", "{1EBEF330-60E4-4E8D-A5BB-092A0AC37412}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TcUnit-Runner-PluginManager", "TcUnit-Runner-PluginManager\TcUnit-Runner-PluginManager.csproj", "{FEC3D0D8-4291-42DC-92ED-3C9DA5AF55D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TcUnit-Runner-PluginManager-Test", "TcUnit-Runner-PluginManager-Test\TcUnit-Runner-PluginManager-Test.csproj", "{E985D732-A453-4D3E-A99F-52D368203AE8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "plugins", "plugins", "{A4261EC1-93CE-479F-84C7-36199F238B2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VariantManager-Plugin", "plugins\VariantManager-Plugin\VariantManager-Plugin.csproj", "{277AD854-5C43-4642-AD59-9646480BC9CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,9 +33,24 @@ Global
 		{1EBEF330-60E4-4E8D-A5BB-092A0AC37412}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EBEF330-60E4-4E8D-A5BB-092A0AC37412}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EBEF330-60E4-4E8D-A5BB-092A0AC37412}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEC3D0D8-4291-42DC-92ED-3C9DA5AF55D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEC3D0D8-4291-42DC-92ED-3C9DA5AF55D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEC3D0D8-4291-42DC-92ED-3C9DA5AF55D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEC3D0D8-4291-42DC-92ED-3C9DA5AF55D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E985D732-A453-4D3E-A99F-52D368203AE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E985D732-A453-4D3E-A99F-52D368203AE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E985D732-A453-4D3E-A99F-52D368203AE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E985D732-A453-4D3E-A99F-52D368203AE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{277AD854-5C43-4642-AD59-9646480BC9CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{277AD854-5C43-4642-AD59-9646480BC9CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{277AD854-5C43-4642-AD59-9646480BC9CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{277AD854-5C43-4642-AD59-9646480BC9CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{277AD854-5C43-4642-AD59-9646480BC9CF} = {A4261EC1-93CE-479F-84C7-36199F238B2C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D490EE58-E37A-4809-8B78-023C45D700F7}

--- a/TcUnit-Runner.sln
+++ b/TcUnit-Runner.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.34301.259
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TcUnit-Runner", "TcUnit-Runner\TcUnit-Runner.csproj", "{107EE0D4-0FD5-42A9-8BA7-58E6FB88BB3D}"
 EndProject

--- a/TcUnit-Runner/Program.cs
+++ b/TcUnit-Runner/Program.cs
@@ -36,6 +36,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using TCatSysManagerLib;
+using TcUnit.TcUnit_Runner.PluginManager;
 using TwinCAT.Ads;
 
 namespace TcUnit.TcUnit_Runner
@@ -51,6 +52,8 @@ namespace TcUnit.TcUnit_Runner
         private static string Timeout = null;
         private static VisualStudioInstance vsInstance;
         private static ILog log = LogManager.GetLogger("TcUnit-Runner");
+
+        private static PluginLoader Plugins;
 
         [STAThread]
         static void Main(string[] args)
@@ -139,6 +142,11 @@ namespace TcUnit.TcUnit_Runner
                 timeout.Start();
             }
 
+            Plugins = new PluginLoader(log);
+            Plugins.LoadOptions(Path.Combine(Path.GetDirectoryName(VisualStudioSolutionFilePath), PluginManager.Constants.XML_PLUGINS_OPTIONS));
+            Plugins.Load();
+
+
             MessageFilter.Register();
 
             TwinCATProjectFilePath = TcFileUtilities.FindTwinCATProjectFile(VisualStudioSolutionFilePath);
@@ -191,6 +199,7 @@ namespace TcUnit.TcUnit_Runner
                 CleanUpAndExitApplication(Constants.RETURN_ERROR_FINDING_VISUAL_STUDIO_SOLUTION_VERSION);
             }
 
+            Plugins.RunAfterSolutionLoadedHooks(vsInstance.GetProject());
 
             AutomationInterface automationInterface = new AutomationInterface(vsInstance.GetProject());
             if (automationInterface.PlcTreeItem.ChildCount <= 0)

--- a/TcUnit-Runner/TcFileUtilities.cs
+++ b/TcUnit-Runner/TcFileUtilities.cs
@@ -5,11 +5,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace TcUnit.TcUnit_Runner
 {
-    class TcFileUtilities
+    public class TcFileUtilities
     {
         private static ILog log = LogManager.GetLogger("TcUnit-Runner");
 
@@ -59,30 +60,24 @@ namespace TcUnit.TcUnit_Runner
             string tcProjectFilePath = "";
             string tcProjectFile = "";
 
-            System.IO.StreamReader file = new System.IO.StreamReader(@VisualStudioSolutionFilePath);
-            while ((line = file.ReadLine()) != null)
+            using (System.IO.StreamReader file = new System.IO.StreamReader(@VisualStudioSolutionFilePath))
             {
-                if (line.StartsWith("Project"))
+
+                while ((line = file.ReadLine()) != null)
                 {
-                    tcProjectFile = Utilities.GetUntilOrEmpty(line, ".tsproj");
-                    break;
+                    var match = Regex.Match(line, "Project\\(\"{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}\"\\) = \"(.+)\", \"(?<tsproj>.+\\.tsproj)\"", RegexOptions.IgnoreCase | RegexOptions.Singleline, TimeSpan.FromSeconds(5));
+                    if (match.Success)
+                    {
+                        tcProjectFile = match.Groups["tsproj"].Value;
+                        break;
+                    }
                 }
+                file.Close();
             }
-            file.Close();
 
             if (!String.IsNullOrEmpty(tcProjectFile))
             {
-                int indexOfTcProjectFile = tcProjectFile.LastIndexOf("\"") + 1;
-                try { 
-                    tcProjectFile = tcProjectFile.Substring(indexOfTcProjectFile, (tcProjectFile.Length- indexOfTcProjectFile));
-
-                    // Add visual studio solution directory path
-                    string VisualStudioSolutionDirectoryPath = Path.GetDirectoryName(VisualStudioSolutionFilePath);
-                    tcProjectFilePath = VisualStudioSolutionDirectoryPath + "\\" + tcProjectFile + ".tsproj";
-                } catch
-                {
-
-                }
+                tcProjectFilePath = Path.Combine(Path.GetDirectoryName(VisualStudioSolutionFilePath), tcProjectFile);
             }
             return tcProjectFilePath;
         }

--- a/TcUnit-Runner/TcUnit-Runner.csproj
+++ b/TcUnit-Runner/TcUnit-Runner.csproj
@@ -159,5 +159,11 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TcUnit-Runner-PluginManager\TcUnit-Runner-PluginManager.csproj">
+      <Project>{fec3d0d8-4291-42dc-92ed-3c9da5af55d0}</Project>
+      <Name>TcUnit-Runner-PluginManager</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/plugins/VariantManager-Plugin/AutomationInterface.cs
+++ b/plugins/VariantManager-Plugin/AutomationInterface.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using TCatSysManagerLib;
+
+namespace TcUnit.TcUnit_Runner.Plugin
+{
+    internal class AutomationInterface
+    {
+        private ITcSysManager15 sysManager = null;
+
+        public AutomationInterface(EnvDTE.Project project)
+        {
+            sysManager = (ITcSysManager15)project.Object;
+        }
+
+        public ITcSysManager15 ITcSysManager => this.sysManager;
+    }
+}

--- a/plugins/VariantManager-Plugin/Properties/AssemblyInfo.cs
+++ b/plugins/VariantManager-Plugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("VariantManager-Plugin")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("VariantManager-Plugin")]
+[assembly: AssemblyCopyright("Copyright © 2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("277ad854-5c43-4642-ad59-9646480bc9cf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.0.1.0")]
+[assembly: AssemblyFileVersion("0.0.1.0")]

--- a/plugins/VariantManager-Plugin/VariantManager-Plugin.csproj
+++ b/plugins/VariantManager-Plugin/VariantManager-Plugin.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{277AD854-5C43-4642-AD59-9646480BC9CF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TcUnit.TcUnit_Runner.Plugin</RootNamespace>
+    <AssemblyName>VariantManager-Plugin</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>..\..\packages\log4net.2.0.14\lib\net45\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AutomationInterface.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VariantManagerPlugin.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\TcUnit-Runner-PluginManager\TcUnit-Runner-PluginManager.csproj">
+      <Project>{fec3d0d8-4291-42dc-92ed-3c9da5af55d0}</Project>
+      <Name>TcUnit-Runner-PluginManager</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="TCatSysManagerLib">
+      <Guid>{3C49D6C3-93DC-11D0-B162-00A0248C244B}</Guid>
+      <VersionMajor>3</VersionMajor>
+      <VersionMinor>3</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/plugins/VariantManager-Plugin/VariantManagerPlugin.cs
+++ b/plugins/VariantManager-Plugin/VariantManagerPlugin.cs
@@ -1,0 +1,64 @@
+﻿using EnvDTE;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TcUnit.TcUnit_Runner.PluginManager.Options;
+using TcUnit.TcUnit_Runner.PluginManager.Plugins;
+
+namespace TcUnit.TcUnit_Runner.Plugin
+{
+
+    [Export(typeof(IAfterSolutionLoadedHook))]
+    public class VariantManagerPlugin : IAfterSolutionLoadedHook
+    {
+        private ILog _log;
+
+        public string Name { get { return "VariantManager"; } }
+
+        public int Run(Project project, ILog log, PluginOptions options)
+        {
+            _log = log;
+            AutomationInterface ai = new AutomationInterface(project);
+            return SetProjectVariant(ai, options);
+        }
+
+
+        private int SetProjectVariant(AutomationInterface automationInterface, PluginOptions options)
+        {
+            var variant = GetVariantFromOptions(options);
+
+            if (string.IsNullOrEmpty(variant))
+            {
+                _log.Error("No variant provided");
+                return -1;
+            }
+
+            try
+            {
+                //Using newer version of ITcSysManager to be able to set variant
+                automationInterface.ITcSysManager.CurrentProjectVariant = variant;
+                _log.Info("Variant selected with name: " + variant);
+                // Wait
+                System.Threading.Thread.Sleep(1000);
+                return 0;
+            }
+            catch
+            {
+                _log.Error("Unable to set variant: " + variant + ". Please provide an existing variant from the project.");
+                return -1;
+            }
+
+        }
+
+        private string GetVariantFromOptions(PluginOptions options)
+        {
+            var plugin = options.GetPluginNodeByAttributeName(Name);
+            return plugin.GetPluginNodeValueByName("Variant");
+        }
+
+    }
+}


### PR DESCRIPTION

This PR adds plugin/hook system to TcUnit-Runner, and 
The plugins are loaded via Managed Extensibility Framework (MEF),
see https://learn.microsoft.com/en-us/dotnet/framework/mef/

It also introduces a kind of hook-system, where hooks are executed during execution of TcUnit-Runner.
These hooks are for example:
- after solution has been loaded
- before build
- after build
- before activating configuration
- after running tests
- ...

A plugin must implement these hooks, e.g. `IAfterSolutionLoadedHook`.
Additionally, configuration of these hooks is done via a dotfile named `.TcUnitRunner`.

Since plugins are optional and only available on runtime, they could help to mitigate issues regarding newer TwinCAT versions/funktions, like
#24 or #25.

I've marked this PR as 'draft', to discuss if this proposal is useful, or introduces other unforeseen issues/problems.

Thanks in advance!